### PR TITLE
Add caching python packages in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@
 FROM python:3.12.7-slim AS builder
 
 WORKDIR /workspace
-  
-COPY ./src . 
-# install python packages in the user´s home(flag -e) to avoid permission issues when not running as root
-RUN pip3 install --user --no-cache-dir -e .
 
+COPY ./src/requirements.txt .
+
+RUN pip3 install --user --no-cache-dir -r requirements.txt
+ 
 # stage runner
 FROM alpine:3 AS runner
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,3 @@
+flask>=2.0.2
+waitress>=2.0.0
+prometheus-flask-exporter==0.23.1


### PR DESCRIPTION
add caching python packages in dockerfile to avoid rebuild de packages if change the python code.

